### PR TITLE
WIP: Training TASTE w/o vq using llama tokenizer (text)

### DIFF
--- a/STAGE1_TRAIN/CosyVoice/cosyvoice/audio/audio_joint_encoder_segmenter.py
+++ b/STAGE1_TRAIN/CosyVoice/cosyvoice/audio/audio_joint_encoder_segmenter.py
@@ -67,6 +67,7 @@ class WhisperAudioJointEncoderSegmenter(BaseAudioJointEncoderSegmenter):
         is_word_level: bool = False,
         skip_prefix_idx: Optional[int] = None,
         vocab_size: int = None,
+        padding_idx: int = None,
         **kwargs,
     ): 
         super().__init__()
@@ -106,9 +107,13 @@ class WhisperAudioJointEncoderSegmenter(BaseAudioJointEncoderSegmenter):
             assert skip_prefix_idx != None, f"To adopt word level averaging, please set `skip_prefix_idx` properly and with cautious."
         self.skip_prefix_idx = skip_prefix_idx
 
-        # Llama tokenizer input
-        if vocab_size and vocab_size == 128256:
-            self.audio_segmenter.decoder.embed_tokens = torch.nn.Embedding(vocab_size, self.audio_segmenter.decoder.embed_tokens.weight.shape[1], padding_idx=128004) # replace the embedding layer
+        # Other tokenizer input
+        if vocab_size is not None:
+            if padding_idx is not None:
+                # replace the embedding layer
+                self.audio_segmenter.decoder.embed_tokens = torch.nn.Embedding(vocab_size, self.audio_segmenter.decoder.embed_tokens.weight.shape[1], padding_idx=padding_idx)
+            else:
+                self.audio_segmenter.decoder.embed_tokens = torch.nn.Embedding(vocab_size, self.audio_segmenter.decoder.embed_tokens.weight.shape[1])
     
     def _initialize_identity(self, target_linear_layer):
         # initialize the target_linear_layer as identity matrix

--- a/STAGE1_TRAIN/CosyVoice/cosyvoice/audio/audio_joint_encoder_segmenter.py
+++ b/STAGE1_TRAIN/CosyVoice/cosyvoice/audio/audio_joint_encoder_segmenter.py
@@ -66,8 +66,7 @@ class WhisperAudioJointEncoderSegmenter(BaseAudioJointEncoderSegmenter):
         make_v_proj_identity: bool = False, 
         is_word_level: bool = False,
         skip_prefix_idx: Optional[int] = None,
-        vocab_size: int = None,
-        padding_idx: int = None,
+        new_vocab: Dict = None,
         **kwargs,
     ): 
         super().__init__()
@@ -108,12 +107,13 @@ class WhisperAudioJointEncoderSegmenter(BaseAudioJointEncoderSegmenter):
         self.skip_prefix_idx = skip_prefix_idx
 
         # Other tokenizer input
-        if vocab_size is not None:
-            if padding_idx is not None:
-                # replace the embedding layer
-                self.audio_segmenter.decoder.embed_tokens = torch.nn.Embedding(vocab_size, self.audio_segmenter.decoder.embed_tokens.weight.shape[1], padding_idx=padding_idx)
+        if new_vocab is not None:
+            if new_vocab.get("vocab_size", None) and new_vocab.get("padding_idx", None):
+                self.audio_segmenter.decoder.embed_tokens = torch.nn.Embedding(new_vocab["vocab_size"], self.audio_segmenter.decoder.embed_tokens.weight.shape[1], padding_idx=new_vocab["padding_idx"])
+            elif new_vocab.get("vocab_size", None):
+                self.audio_segmenter.decoder.embed_tokens = torch.nn.Embedding(new_vocab["vocab_size"], self.audio_segmenter.decoder.embed_tokens.weight.shape[1])
             else:
-                self.audio_segmenter.decoder.embed_tokens = torch.nn.Embedding(vocab_size, self.audio_segmenter.decoder.embed_tokens.weight.shape[1])
+                raise ValueError("Plese provide vocab_size in new_vocab")
     
     def _initialize_identity(self, target_linear_layer):
         # initialize the target_linear_layer as identity matrix

--- a/STAGE1_TRAIN/CosyVoice/cosyvoice/audio/audio_joint_encoder_segmenter.py
+++ b/STAGE1_TRAIN/CosyVoice/cosyvoice/audio/audio_joint_encoder_segmenter.py
@@ -66,6 +66,7 @@ class WhisperAudioJointEncoderSegmenter(BaseAudioJointEncoderSegmenter):
         make_v_proj_identity: bool = False, 
         is_word_level: bool = False,
         skip_prefix_idx: Optional[int] = None,
+        vocab_size: int = None,
         **kwargs,
     ): 
         super().__init__()
@@ -104,6 +105,10 @@ class WhisperAudioJointEncoderSegmenter(BaseAudioJointEncoderSegmenter):
             print("Would adopt word-level averaging")
             assert skip_prefix_idx != None, f"To adopt word level averaging, please set `skip_prefix_idx` properly and with cautious."
         self.skip_prefix_idx = skip_prefix_idx
+
+        # Llama tokenizer input
+        if vocab_size and vocab_size == 128256:
+            self.audio_segmenter.decoder.embed_tokens = torch.nn.Embedding(vocab_size, self.audio_segmenter.decoder.embed_tokens.weight.shape[1], padding_idx=128004) # replace the embedding layer
     
     def _initialize_identity(self, target_linear_layer):
         # initialize the target_linear_layer as identity matrix

--- a/STAGE1_TRAIN/CosyVoice/examples/emilia/taste/conf/taste_no_vq_llama.yaml
+++ b/STAGE1_TRAIN/CosyVoice/examples/emilia/taste/conf/taste_no_vq_llama.yaml
@@ -1,0 +1,301 @@
+# set random seed, so that you may reproduce your result.
+__set_seed1: !apply:random.seed [1986]
+__set_seed2: !apply:numpy.random.seed [1986]
+__set_seed3: !apply:torch.manual_seed [1986]
+__set_seed4: !apply:torch.cuda.manual_seed_all [1986]
+
+# fixed params
+sample_rate: 22050
+text_encoder_input_size: 512
+llm_input_size: 1024
+llm_output_size: 1024
+spk_embed_dim: 192
+## for audio branch
+is_word_level: False
+audio_embed_dim: 1280
+audio_token_encoder_input_size: 512
+# TODO: you should modify whisper_tokenizer_fpath for your own need
+# TODO: change to llama tokenizer
+whisper_tokenizer_fpath: /proj/MR_dataset/mtk53711/TASTE-SpokenLM/STAGE1_TRAIN/storage/pretrained_models/Llama-3.2-1B
+whisper_encoder_fpath: /proj/MR_dataset/mtk53711/TASTE-SpokenLM/STAGE1_TRAIN/storage/pretrained_models/distil-large-v3
+
+# model params
+# for all class/function included in this repo, we use !<name> or !<new> for intialization, so that user may find all corresponding class/function according to one single yaml.
+# for system/third_party class/function, we do not require this.
+llm: !new:cosyvoice.llm.audio_llm.TransformerJointLM
+  load_partial_list: [
+      "text_encoder",
+      "llm",
+      "llm_decoder",
+      "audio_tokenizer", # add this would probably simulate fully loaded
+      "audio_token_encoder",
+      "audio_embed_affine_layer",
+    ]
+  freeze_partial_list: [
+      "audio_tokenizer.audio_joint_encoder_segmenter.audio_encoder", # Freeze encoder
+      "audio_tokenizer.audio_joint_encoder_segmenter.audio_segmenter.decoder.layers", # Freeze all decoder layers
+      # Removed decoder.embed from freeze list to allow training embeddings
+    ]
+  freeze_partial_during_init: True
+  text_encoder_input_size: !ref <text_encoder_input_size>
+  llm_input_size: !ref <llm_input_size>
+  llm_output_size: !ref <llm_output_size>
+  text_token_size: 128256
+  speech_token_size: 4096
+  length_normalized_loss: True
+  lsm_weight: 0
+  spk_embed_dim: !ref <spk_embed_dim>
+  # for audio branch
+  audio_embed_dim: !ref <audio_embed_dim>
+  audio_token_encoder_input_size: !ref <audio_token_encoder_input_size>
+  is_word_level: !ref <is_word_level>
+  fuse_encoded_audio_text_type: "weighted_sum"
+  fuse_encoded_audio_text_kwargs:
+    normalize: True
+    use_trainable_weight: True
+    use_layer_norm: False
+    weight_init_type: "balance"
+    # audio_first: True # audio first seems
+  audio_tokenizer:
+    !new:cosyvoice.audio.audio_tokenizer.JointEncoderSegmenterAudioTokenizer
+    audio_joint_encoder_segmenter:
+      !new:cosyvoice.audio.audio_joint_encoder_segmenter.WhisperAudioJointEncoderSegmenter
+      model_name_or_path: !ref <whisper_encoder_fpath>
+      # attn_implementation: flash_attention_2
+      attn_implementation: eager
+      # dtype: bfloat16
+      dtype: float32
+      use_custom: True
+      forward_type: asr_attn_pooling
+      make_v_proj_identity: True
+      is_word_level: !ref <is_word_level>
+      skip_prefix_idx: 1 # skip bos (0), task_id (1), lang_id (2), no-timestamp (3), start from idx=4
+      vocab_size: 128256 # Set vocab size to match text_token_size
+      # skip_postfix_idx: -1 # skip eos (-1), currently unsupported
+    audio_quantizer:
+      !new:cosyvoice.audio.audio_quantizer.StraightThroughAudioQuantizer # audio token encoder is parallel with the text_encoder below
+
+
+  audio_token_encoder: !new:cosyvoice.transformer.encoder.ConformerEncoder
+    input_size: !ref <audio_token_encoder_input_size>
+    output_size: 1024
+    attention_heads: 8
+    linear_units: 2048
+    num_blocks: 2
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0
+    normalize_before: True
+    input_layer: "linear"
+    pos_enc_layer_type: "rel_pos_espnet"
+    selfattention_layer_type: "rel_selfattn"
+    use_cnn_module: False
+    macaron_style: False
+    use_dynamic_chunk: False
+    use_dynamic_left_chunk: False
+    static_chunk_size: 1
+  # end of audio branch
+  text_encoder: !new:cosyvoice.transformer.encoder.ConformerEncoder
+    input_size: !ref <text_encoder_input_size>
+    output_size: 1024
+    attention_heads: 8
+    linear_units: 2048
+    num_blocks: 3
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0
+    normalize_before: True
+    input_layer: "linear"
+    pos_enc_layer_type: "rel_pos_espnet"
+    selfattention_layer_type: "rel_selfattn"
+    use_cnn_module: False
+    macaron_style: False
+    use_dynamic_chunk: False
+    use_dynamic_left_chunk: False
+    static_chunk_size: 1
+  llm: !new:cosyvoice.transformer.encoder.TransformerEncoder
+    input_size: !ref <llm_input_size>
+    output_size: !ref <llm_output_size>
+    attention_heads: 8
+    linear_units: 2048
+    num_blocks: 7
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0
+    input_layer: "linear_legacy"
+    pos_enc_layer_type: "rel_pos_espnet"
+    selfattention_layer_type: "rel_selfattn"
+    static_chunk_size: 1
+
+flow: !new:cosyvoice.flow.flow.MaskedDiffWithXvec
+  input_size: 512
+  output_size: 80
+  spk_embed_dim: !ref <spk_embed_dim>
+  output_type: "mel"
+  vocab_size: 4096
+  input_frame_rate: 50
+  only_mask_loss: True
+  encoder: !new:cosyvoice.transformer.encoder.ConformerEncoder
+    output_size: 512
+    attention_heads: 8
+    linear_units: 2048
+    num_blocks: 6
+    dropout_rate: 0.1
+    positional_dropout_rate: 0.1
+    attention_dropout_rate: 0.1
+    normalize_before: True
+    input_layer: "linear"
+    pos_enc_layer_type: "rel_pos_espnet"
+    selfattention_layer_type: "rel_selfattn"
+    input_size: 512
+    use_cnn_module: False
+    macaron_style: False
+  length_regulator: !new:cosyvoice.flow.length_regulator.InterpolateRegulator
+    channels: 80
+    sampling_ratios: [1, 1, 1, 1]
+  decoder: !new:cosyvoice.flow.flow_matching.ConditionalCFM
+    in_channels: 240
+    n_spks: 1
+    spk_emb_dim: 80
+    cfm_params: !new:omegaconf.DictConfig
+      content:
+        sigma_min: 1e-06
+        solver: "euler"
+        t_scheduler: "cosine"
+        training_cfg_rate: 0.2
+        inference_cfg_rate: 0.7
+        reg_loss_type: "l1"
+    estimator: !new:cosyvoice.flow.decoder.ConditionalDecoder
+      in_channels: 320
+      out_channels: 80
+      channels: [256, 256]
+      dropout: 0
+      attention_head_dim: 64
+      n_blocks: 4
+      num_mid_blocks: 12
+      num_heads: 8
+      act_fn: "gelu"
+
+hift: !new:cosyvoice.hifigan.generator.HiFTGenerator
+  in_channels: 80
+  base_channels: 512
+  nb_harmonics: 8
+  sampling_rate: !ref <sample_rate>
+  nsf_alpha: 0.1
+  nsf_sigma: 0.003
+  nsf_voiced_threshold: 10
+  upsample_rates: [8, 8]
+  upsample_kernel_sizes: [16, 16]
+  istft_params:
+    n_fft: 16
+    hop_len: 4
+  resblock_kernel_sizes: [3, 7, 11]
+  resblock_dilation_sizes: [[1, 3, 5], [1, 3, 5], [1, 3, 5]]
+  source_resblock_kernel_sizes: [7, 11]
+  source_resblock_dilation_sizes: [[1, 3, 5], [1, 3, 5]]
+  lrelu_slope: 0.1
+  audio_limit: 0.99
+  f0_predictor: !new:cosyvoice.hifigan.f0_predictor.ConvRNNF0Predictor
+    num_class: 1
+    in_channels: 80
+    cond_channels: 512
+
+# processor functions
+parquet_opener: !name:cosyvoice.dataset.processor.parquet_opener
+get_tokenizer: !name:whisper.tokenizer.get_tokenizer
+  multilingual: True
+  num_languages: 100
+  language: "en"
+  task: "transcribe"
+allowed_special: "all"
+tokenize: !name:cosyvoice.dataset.processor.tokenize_by_words
+  get_tokenizer: !ref <get_tokenizer>
+  allowed_special: !ref <allowed_special>
+  use_asr_text: True
+tokenize_whisper: !name:cosyvoice.dataset.processor.tokenize_whisper
+  whisper_tokenizer_name_or_fpath: !ref <whisper_tokenizer_fpath>
+  task: "transcribe"
+  language: "en"
+  no_timestamps: True
+  add_bos: True
+  add_eos: False
+  use_asr_text: True
+  overwrite_text_token: False
+  use_wrapped: True
+filter: !name:cosyvoice.dataset.processor.filter
+  max_length: 40960
+  min_length: 0
+  token_max_length: 200
+  token_min_length: 1
+resample: !name:cosyvoice.dataset.processor.resample
+  resample_rate: !ref <sample_rate>
+feat_extractor: !name:matcha.utils.audio.mel_spectrogram
+  n_fft: 1024
+  num_mels: 80
+  sampling_rate: !ref <sample_rate>
+  hop_size: 256
+  win_size: 1024
+  fmin: 0
+  fmax: 8000
+  center: False
+audio_extractor: !new:funasr.frontends.whisper_frontend.WhisperFrontend
+  whisper_model: large-v3
+  do_pad_trim: True
+  permute: True
+extract_audio:
+  !name:cosyvoice.dataset.processor.extract_audio # get_audio_extractor: !ref <get_audio_extractor>
+  audio_extractor: !ref <audio_extractor>
+  target_sample_rate: 16_000
+  # Maybe we should add prepending sensevoice tokens here.
+compute_fbank: !name:cosyvoice.dataset.processor.compute_fbank
+  feat_extractor: !ref <feat_extractor>
+parse_embedding: !name:cosyvoice.dataset.processor.parse_embedding
+  normalize: True
+shuffle: !name:cosyvoice.dataset.processor.shuffle
+  shuffle_size: 1000
+sort: !name:cosyvoice.dataset.processor.sort
+  sort_size: 500 # sort_size should be less than shuffle_size
+batch: !name:cosyvoice.dataset.processor.batch
+  batch_size: 4
+  batch_type: "dynamic"
+  # max_frames_in_batch: 16000 # 4800
+  max_frames_in_batch: 2000 # for testing
+padding: !name:cosyvoice.dataset.processor.padding
+  use_spk_embedding: False # change to True during sft
+  has_audio_branch: True # add audio branch related padding
+  use_asr_text: False # avoid directly using asr text and alignments for compatibility
+  use_auto_audio_len: False
+  requires_words_index: !ref <is_word_level> # for word-level audio token
+
+# dataset processor pipeline
+data_pipeline: [
+    !ref <parquet_opener>,
+    !ref <tokenize>, # using tokenize_whisper can skip this
+    !ref <tokenize_whisper>,
+    !ref <filter>,
+    !ref <extract_audio>, # added for audio branch, NOTE: should be in front of resample and compute fbank!!
+    !ref <resample>,
+    !ref <compute_fbank>,
+    !ref <parse_embedding>,
+    !ref <shuffle>,
+    !ref <sort>,
+    !ref <batch>,
+    !ref <padding>,
+  ]
+
+# train conf
+train_conf:
+  optim: adam
+  optim_conf:
+    lr: 0.0016 # change to 0.001 if you want to train flow from scratch
+  scheduler: warmuplr
+  scheduler_conf:
+    # warmup_steps: 25000
+    warmup_steps: 20000
+  # max_epoch: 200
+  max_epoch: 5
+  grad_clip: 5
+  accum_grad: 2 # 6
+  log_interval: 100
+  save_per_step: 10000
+  # save_per_step: 50 # for testing

--- a/STAGE1_TRAIN/CosyVoice/examples/emilia/taste/conf/taste_no_vq_llama.yaml
+++ b/STAGE1_TRAIN/CosyVoice/examples/emilia/taste/conf/taste_no_vq_llama.yaml
@@ -71,6 +71,7 @@ llm: !new:cosyvoice.llm.audio_llm.TransformerJointLM
       is_word_level: !ref <is_word_level>
       skip_prefix_idx: 1 # skip bos (0), task_id (1), lang_id (2), no-timestamp (3), start from idx=4
       vocab_size: 128256 # Set vocab size to match text_token_size
+      padding_idx: 128004
       # skip_postfix_idx: -1 # skip eos (-1), currently unsupported
     audio_quantizer:
       !new:cosyvoice.audio.audio_quantizer.StraightThroughAudioQuantizer # audio token encoder is parallel with the text_encoder below

--- a/STAGE1_TRAIN/CosyVoice/examples/emilia/taste/conf/taste_no_vq_llama.yaml
+++ b/STAGE1_TRAIN/CosyVoice/examples/emilia/taste/conf/taste_no_vq_llama.yaml
@@ -70,8 +70,9 @@ llm: !new:cosyvoice.llm.audio_llm.TransformerJointLM
       make_v_proj_identity: True
       is_word_level: !ref <is_word_level>
       skip_prefix_idx: 1 # skip bos (0), task_id (1), lang_id (2), no-timestamp (3), start from idx=4
-      vocab_size: 128256 # Set vocab size to match text_token_size
-      padding_idx: 128004
+      new_vocab:
+        vocab_size: 128256 # Set vocab size to match text_token_size
+        padding_idx: 128004
       # skip_postfix_idx: -1 # skip eos (-1), currently unsupported
     audio_quantizer:
       !new:cosyvoice.audio.audio_quantizer.StraightThroughAudioQuantizer # audio token encoder is parallel with the text_encoder below

--- a/STAGE1_TRAIN/CosyVoice/examples/emilia/taste/conf/taste_no_vq_llama.yaml
+++ b/STAGE1_TRAIN/CosyVoice/examples/emilia/taste/conf/taste_no_vq_llama.yaml
@@ -214,7 +214,7 @@ tokenize: !name:cosyvoice.dataset.processor.tokenize_by_words
   allowed_special: !ref <allowed_special>
   use_asr_text: True
 tokenize_whisper: !name:cosyvoice.dataset.processor.tokenize_whisper
-  whisper_tokenizer_name_or_fpath: !ref <whisper_tokenizer_fpath>
+  tokenizer_name_or_fpath: !ref <whisper_tokenizer_fpath>
   task: "transcribe"
   language: "en"
   no_timestamps: True
@@ -294,7 +294,7 @@ train_conf:
     # warmup_steps: 25000
     warmup_steps: 20000
   # max_epoch: 200
-  max_epoch: 5
+  max_epoch: 3
   grad_clip: 5
   accum_grad: 2 # 6
   log_interval: 100

--- a/STAGE1_TRAIN/CosyVoice/examples/emilia/taste/run_train_taste_llama.sh
+++ b/STAGE1_TRAIN/CosyVoice/examples/emilia/taste/run_train_taste_llama.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Copyright 2024 Alibaba Inc. All Rights Reserved.
+set -e
+# please run this script with `bash run_train_taste.sh`, or the relative fpath will be incorrect.
+
+source ../../../../path.sh
+
+stage=3
+stop_stage=3
+
+pretrained_model_dir=$RTSLM_STORAGE_DIR/pretrained_models/CosyVoice-300M
+DATA_ROOT=$RTSLM_STORAGE_DIR/data/ # change to your own
+export CUDA_VISIBLE_DEVICES="2,3" # change for your own need
+
+# prepare data for example usage
+if [ ${stage} -le 1 ] && [ ${stop_stage} -ge 1 ]; then
+    # prepare data list (for example usage)
+    ls -a $DATA_ROOT/train/*.arrow > data/train.data.list
+    ls -a $DATA_ROOT/dev/*.arrow > data/dev.data.list
+    ls -a $DATA_ROOT/test/*.arrow > data/test.data.list
+fi
+
+# train text only baseline
+if [ ${stage} -le 2 ] && [ ${stop_stage} -ge 2 ]; then
+    EXP_NAME="text-only_baseline"
+    conf_fpath="./conf/$EXP_NAME.yaml"
+    num_gpus=$(echo $CUDA_VISIBLE_DEVICES | awk -F "," '{print NF}')
+    _OMP_NUM_THREADS=$num_gpus
+    job_id=1986
+    dist_backend="nccl"
+    data_loader_num_workers=2
+    prefetch=8
+    train_engine=torch_ddp
+    model=llm
+    echo "Conduct training of the text-only baseline."
+    echo "Training info: CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES; num_gpus=$num_gpus; dataloader_num_workers=$data_loader_num_workers"
+    # start training modules
+    mkdir -p ./exp/$model/$train_engine/$EXP_NAME
+    cp $0 ./exp/$model/$train_engine/$EXP_NAME
+    NCCL_DEBUG=TRACE OMP_NUM_THREADS=$_OMP_NUM_THREADS torchrun --nnodes=1 --nproc_per_node=$num_gpus --master_port 12345 \
+        --rdzv_id=$job_id --rdzv_backend="c10d" --rdzv_endpoint="localhost:0" \
+        $RTSLM_WORK_DIR/CosyVoice/cosyvoice/bin/train.py \
+        --train_engine $train_engine \
+        --config $conf_fpath \
+        --train_data ./data/train.data.list \
+        --cv_data ./data/dev.data.list \
+        --model $model \
+        --model_dir ./exp/$model/$train_engine/$EXP_NAME \
+        --tensorboard_dir ./tensorboard/$model/$train_engine/$EXP_NAME \
+        --ddp.dist_backend $dist_backend \
+        --num_workers ${data_loader_num_workers} \
+        --prefetch ${prefetch} \
+        --pin_memory \
+        --timeout 30 \
+        --deepspeed_config ./conf/customized_ds.json \
+        --deepspeed.save_states model+optimizer 
+        # --checkpoint $ckpt_fpath # for resuming
+fi
+
+
+# train TASTE w/o quantizer
+if [ ${stage} -le 3 ] && [ ${stop_stage} -ge 3 ]; then
+    EXP_NAME="taste_no_vq_llama"
+    # ckpt_fpath="./exp/llm/torch_ddp/text-only_baseline/checkpoint_best.pt" # initialize from text-only baseline for efficiency
+    ckpt_fpath="./exp/text-only_baseline/checkpoint_llama.pt"
+    conf_fpath="./conf/$EXP_NAME.yaml"
+
+    num_gpus=$(echo $CUDA_VISIBLE_DEVICES | awk -F "," '{print NF}')
+    _OMP_NUM_THREADS=$num_gpus
+    job_id=1986
+    dist_backend="nccl"
+    data_loader_num_workers=2
+    prefetch=8
+    train_engine=torch_ddp
+    model=llm
+    echo "Conduct training of the taste without vq."
+    echo "Training info: CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES; num_gpus=$num_gpus; dataloader_num_workers=$data_loader_num_workers"
+    # start training modules
+    mkdir -p ./exp/$model/$train_engine/$EXP_NAME
+    cp $0 ./exp/$model/$train_engine/$EXP_NAME
+    NCCL_DEBUG=DEBUG OMP_NUM_THREADS=$_OMP_NUM_THREADS torchrun --nnodes=1 --nproc_per_node=$num_gpus \
+        --rdzv_id=$job_id --rdzv_backend="c10d" --rdzv_endpoint="localhost:0" \
+        $RTSLM_WORK_DIR/CosyVoice/cosyvoice/bin/train.py \
+        --train_engine $train_engine \
+        --config $conf_fpath \
+        --train_data ./data/train.data.list \
+        --cv_data ./data/dev.data.list \
+        --model $model \
+        --model_dir ./exp/$model/$train_engine/$EXP_NAME \
+        --tensorboard_dir ./tensorboard/$model/$train_engine/$EXP_NAME \
+        --ddp.dist_backend $dist_backend \
+        --num_workers ${data_loader_num_workers} \
+        --prefetch ${prefetch} \
+        --pin_memory \
+        --timeout 30 \
+        --deepspeed_config ./conf/customized_ds.json \
+        --deepspeed.save_states model+optimizer \
+        --checkpoint $ckpt_fpath
+fi
+
+
+# train TASTE with rvq_quantizer
+if [ ${stage} -le 4 ] && [ ${stop_stage} -ge 4 ]; then
+    EXP_NAME="taste"
+    ckpt_fpath="./exp/llm/torch_ddp/taste_no_vq/checkpoint_best.pt" # initialize from text-only baseline for efficiency
+    conf_fpath="./conf/$EXP_NAME.yaml"
+
+    num_gpus=$(echo $CUDA_VISIBLE_DEVICES | awk -F "," '{print NF}')
+    _OMP_NUM_THREADS=$num_gpus
+    job_id=1986
+    dist_backend="nccl"
+    data_loader_num_workers=2
+    prefetch=8
+    train_engine=torch_ddp
+    model=llm
+    echo "Conduct training of the taste with rvq."
+    echo "Training info: CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES; num_gpus=$num_gpus; dataloader_num_workers=$data_loader_num_workers"
+    if [ $train_engine == 'deepspeed' ]; then
+      echo "Notice deepspeed has its own optimizer config. Modify conf/ds_stage2.json if necessary"
+    fi
+    # start training modules
+    mkdir -p ./exp/$model/$train_engine/$EXP_NAME
+    cp $0 ./exp/$model/$train_engine/$EXP_NAME
+    NCCL_DEBUG=DEBUG OMP_NUM_THREADS=$_OMP_NUM_THREADS torchrun --nnodes=1 --nproc_per_node=$num_gpus \
+        --rdzv_id=$job_id --rdzv_backend="c10d" --rdzv_endpoint="localhost:0" \
+        $RTSLM_WORK_DIR/CosyVoice/cosyvoice/bin/train.py \
+        --train_engine $train_engine \
+        --config $conf_fpath \
+        --train_data ./data/train.data.list \
+        --cv_data ./data/dev.data.list \
+        --model $model \
+        --model_dir ./exp/$model/$train_engine/$EXP_NAME \
+        --tensorboard_dir ./tensorboard/$model/$train_engine/$EXP_NAME \
+        --ddp.dist_backend $dist_backend \
+        --num_workers ${data_loader_num_workers} \
+        --prefetch ${prefetch} \
+        --pin_memory \
+        --timeout 30 \
+        --deepspeed_config ./conf/customized_ds.json \
+        --deepspeed.save_states model+optimizer \
+        --checkpoint $ckpt_fpath
+fi

--- a/STAGE1_TRAIN/storage/modify_ckpt_to_llama.py
+++ b/STAGE1_TRAIN/storage/modify_ckpt_to_llama.py
@@ -1,0 +1,129 @@
+import torch
+import sys
+import os
+from collections import OrderedDict
+
+# Add CosyVoice to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '../CosyVoice'))
+
+from cosyvoice.llm.llm import TransformerLM
+from cosyvoice.transformer.encoder import ConformerEncoder, TransformerEncoder
+
+def print_module_info(model):
+    print("\nDetailed Model Architecture:")
+    for name, module in model.named_modules():
+        if len(name) > 0:  # Skip the root module
+            print(f"\nModule: {name}")
+            print(f"Type: {type(module).__name__}")
+            
+            # Get parameters
+            params = sum(p.numel() for p in module.parameters())
+            print(f"Parameters: {params:,}")
+            
+            # Try to get input/output dimensions if available
+            if hasattr(module, 'in_features'):
+                print(f"Input features: {module.in_features}")
+            if hasattr(module, 'out_features'):
+                print(f"Output features: {module.out_features}")
+            if hasattr(module, 'in_channels'):
+                print(f"Input channels: {module.in_channels}")
+            if hasattr(module, 'out_channels'):
+                print(f"Output channels: {module.out_channels}")
+            if hasattr(module, 'input_size'):
+                print(f"Input size: {module.input_size}")
+            if hasattr(module, 'output_size'):
+                print(f"Output size: {module.output_size}")
+
+def main():
+    # Load checkpoint
+    checkpoint_path = './checkpoints/text-only_baseline/checkpoint_best.pt'
+    print(f"Loading checkpoint from {checkpoint_path}")
+    
+    checkpoint = torch.load(checkpoint_path, map_location='cpu')
+    
+    # Print checkpoint keys
+    print("\nCheckpoint keys:")
+    for key in checkpoint.keys():
+        if isinstance(checkpoint[key], dict):
+            print(f"{key}:")
+            for subkey in checkpoint[key].keys():
+                print(f"  {subkey}")
+        else:
+            print(key)
+    
+    # Create model according to config
+    model = TransformerLM(
+        text_encoder_input_size=512,
+        llm_input_size=1024,
+        llm_output_size=1024,
+        text_token_size=128256,  # Modified to get desired embedding shape
+        speech_token_size=4096,
+        length_normalized_loss=True,
+        lsm_weight=0,
+        spk_embed_dim=192,
+        text_encoder=ConformerEncoder(
+            input_size=512,
+            output_size=1024,
+            attention_heads=8,
+            linear_units=2048,
+            num_blocks=3,
+            dropout_rate=0.1,
+            positional_dropout_rate=0.1,
+            attention_dropout_rate=0,
+            normalize_before=True,
+            input_layer='linear',
+            pos_enc_layer_type='rel_pos_espnet',
+            selfattention_layer_type='rel_selfattn',
+            use_cnn_module=False,
+            macaron_style=False,
+            use_dynamic_chunk=False,
+            use_dynamic_left_chunk=False,
+            static_chunk_size=1
+        ),
+        llm=TransformerEncoder(
+            input_size=1024,
+            output_size=1024,
+            attention_heads=8,
+            linear_units=2048,
+            num_blocks=7,
+            dropout_rate=0.1,
+            positional_dropout_rate=0.1,
+            attention_dropout_rate=0,
+            input_layer='linear_legacy',
+            pos_enc_layer_type='rel_pos_espnet',
+            selfattention_layer_type='rel_selfattn',
+            static_chunk_size=1
+        )
+    )
+    
+    # Load checkpoint
+    checkpoint = torch.load(checkpoint_path, map_location=torch.device('cpu'))
+    state_dict = checkpoint
+    
+    # Create new text embedding weight with desired shape
+    print("\nCreating new text embedding weight with shape [128256, 512]")
+    new_embedding = torch.zeros(128256, 512)
+    # Initialize with xavier uniform for better starting point
+    torch.nn.init.xavier_uniform_(new_embedding)
+    
+    # Replace text embedding in state dict
+    state_dict['text_embedding.weight'] = new_embedding
+    
+    # Load state dict with new embedding
+    model.load_state_dict(state_dict)
+    print("\nModel loaded successfully!")
+    print_module_info(model)
+        
+    # Print state dict keys to see all available tensors
+    print("\nModel State Dict Keys and Shapes:")
+    for key, tensor in model.state_dict().items():
+        print(f"{key}: {tensor.shape}")
+    
+    # Save the modified model
+    output_path = './checkpoints/text-only_baseline/checkpoint_llama.pt'
+    print(f"\nSaving modified model to {output_path}")
+    torch.save(model.state_dict(), output_path)
+    print("Model saved successfully!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Training TASTE w/o vq, using llama tokenizer (Llama-3.2-1B)
- Modify distil-whisper's decoder embedding dimensions to fit llama token size
- Modify tokenize stage in data-processing (whisper --> llama)
- Borrowing the weights from pretrained text-only_baseline model, and replacing the embedding layer
- Create a temporary training config (`taste_no_vq_llama.yaml`)